### PR TITLE
Time filter

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -19,7 +19,7 @@ class EventsController < ApplicationController
 
       Events::FilteredQuery.new(filter: filter).all
     else
-      town.events
+      Event.all
     end
   end
 

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -24,6 +24,6 @@ class EventsController < ApplicationController
   end
 
   def filter_params
-    params[:filter].permit(:town_id)
+    params[:filter].permit(:town_id, :max_starts_at, :min_starts_at)
   end
 end

--- a/app/query_objects/events/filtered_query.rb
+++ b/app/query_objects/events/filtered_query.rb
@@ -7,17 +7,37 @@ module Events
 
     def all
       by_town
+      by_min_starts_at
+      by_max_starts_at
     end
 
     private
 
     def by_town
       return @relation if town.blank?
-      @relation.where(town: town)
+      @relation = @relation.where(town: town)
+    end
+
+    def by_min_starts_at
+      return @relation if min_starts_at.blank?
+      @relation = @relation.where("starts_at > ?", min_starts_at)
+    end
+
+    def by_max_starts_at
+      return @relation if max_starts_at.blank?
+      @relation = @relation.where("starts_at < ?", max_starts_at)
     end
 
     def town
       @options[:town] || filter && filter.town
+    end
+
+    def max_starts_at
+      @options[:max_starts_at] || filter && filter.max_starts_at
+    end
+
+    def min_starts_at
+      @options[:min_starts_at] || filter && filter.min_starts_at
     end
 
     def filter

--- a/app/views/events/index.html.slim
+++ b/app/views/events/index.html.slim
@@ -9,4 +9,6 @@
 
     = simple_form_for filter, url: events_path, method: :get do |f|
       = f.association :town, label_method: :name
+      = f.input :min_starts_at
+      = f.input :max_starts_at
       = f.submit "Apply Filter"

--- a/app/views/towns/events/index.html.slim
+++ b/app/views/towns/events/index.html.slim
@@ -9,4 +9,6 @@
 
     = simple_form_for filter, url: events_path, method: :get do |f|
       = f.association :town, label_method: :name
+      = f.input :min_starts_at
+      = f.input :max_starts_at
       = f.submit "Apply Filter"

--- a/db/migrate/20180618093553_add_starts_ends_to_filter.rb
+++ b/db/migrate/20180618093553_add_starts_ends_to_filter.rb
@@ -1,0 +1,6 @@
+class AddStartsEndsToFilter < ActiveRecord::Migration[5.1]
+  def change
+    add_column :filters, :min_starts_at, :timestamp
+    add_column :filters, :max_starts_at, :timestamp
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180618081928) do
+ActiveRecord::Schema.define(version: 20180618093553) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -49,6 +49,8 @@ ActiveRecord::Schema.define(version: 20180618081928) do
     t.bigint "town_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "min_starts_at"
+    t.datetime "max_starts_at"
     t.index ["town_id"], name: "index_filters_on_town_id"
   end
 

--- a/spec/features/user/towns/events_spec.rb
+++ b/spec/features/user/towns/events_spec.rb
@@ -6,6 +6,13 @@ feature "List of events in the town" do
   let(:default_city) { create :town, name: "Dafault city" }
   let(:midtown) { create :town, name: "Midtown" }
   let!(:fishing) { create :event, title: "Fishing", town: midtown }
+  let!(:expired_event) do
+    create :event,
+      title: "October revolution",
+      town: midtown,
+      min_starts_at: 100.years.ago,
+      max_starts_at: 90.years.ago
+  end
   let!(:concert) { create :event, title: "Mr.Default's concert", town: default_city }
   let!(:birthday) { create :event, title: "Default city birthday", town: default_city }
 

--- a/spec/features/user/towns/events_spec.rb
+++ b/spec/features/user/towns/events_spec.rb
@@ -10,8 +10,7 @@ feature "List of events in the town" do
     create :event,
       title: "October revolution",
       town: midtown,
-      min_starts_at: 100.years.ago,
-      max_starts_at: 90.years.ago
+      starts_at: 100.years.ago
   end
   let!(:concert) { create :event, title: "Mr.Default's concert", town: default_city }
   let!(:birthday) { create :event, title: "Default city birthday", town: default_city }
@@ -28,9 +27,12 @@ feature "List of events in the town" do
     visit town_events_path(default_city)
 
     select "Midtown", from: "Town"
+    select "2017", from: "filter_min_starts_at_1i"
+    select "2020", from: "filter_max_starts_at_1i"
     click_button "Apply Filter"
 
     expect(page).to have_content("Fishing")
+    expect(page).not_to have_content("October revolution")
     expect(page).not_to have_content("Mr.Default's concert")
     expect(page).not_to have_content("Default city birthday")
   end

--- a/spec/query_objects/events/filtered_query_spec.rb
+++ b/spec/query_objects/events/filtered_query_spec.rb
@@ -6,6 +6,7 @@ describe Events::FilteredQuery do
   let(:town) { create :town, name: "Default city" }
   let!(:default_events) { create_list :event, 2, town: town }
   let!(:other_events) { create_list :event, 2 }
+  let!(:expired_event) { create :event, starts_at: 1.year.ago, town: town }
 
   context "when no options is provided" do
     let(:query_options) { nil }
@@ -19,16 +20,32 @@ describe Events::FilteredQuery do
     let(:query_options) { { town: town } }
 
     it "returns events associated with town" do
-      expect(filtered_events).to eq default_events
+      expect(filtered_events).to match_array(default_events + [expired_event])
     end
   end
 
   context "when filter is provided" do
-    let(:filter) { build :filter, town: town }
     let(:query_options) { { filter: filter } }
 
-    it "returns events associated with town" do
-      expect(filtered_events).to eq default_events
+    context "when town is specified" do
+      let(:filter) { build :filter, town: town }
+
+      it "returns events associated with town" do
+        expect(filtered_events).to match_array(default_events + [expired_event])
+      end
+    end
+
+    context "when town and start time range specified" do
+      let(:filter) do
+        build :filter,
+          town: town,
+          min_starts_at: 100.years.ago,
+          max_starts_at: 2.days.ago
+      end
+
+      it "returns events associated with town" do
+        expect(filtered_events).to match_array [expired_event]
+      end
     end
   end
 end


### PR DESCRIPTION
- extend query object to accept `event_starts_at` time ranges
- allow user to set event ranges in filter