### PR TITLE
Add background job that sends email notification for users that have a matching filter

### DIFF
--- a/app/jobs/notify_subscribers_job.rb
+++ b/app/jobs/notify_subscribers_job.rb
@@ -1,0 +1,27 @@
+class NotifySubscribersJob < ApplicationJob
+  def perform(options)
+    @event_id = options[:event_id]
+
+    filters_id_user_id.group_by(&:user_id).each do |user_id, user_filters|
+      NotifySubscriberJob.perform_later(
+        subscriber_id: user_id,
+        filter_ids: user_filters.map(&:id).sort,
+        event_id: @event_id
+      )
+    end
+  end
+
+  private
+
+  def event
+    @event ||= Event.find(@event_id)
+  end
+
+  def filters_id_user_id
+    @filter_ids ||= matching_filters.select(:id, :user_id)
+  end
+
+  def matching_filters
+    @matching_filters ||= Events::MatchingFiltersQuery.new(event).all
+  end
+end

--- a/app/mailers/subscriber_mailer.rb
+++ b/app/mailers/subscriber_mailer.rb
@@ -3,6 +3,7 @@ class SubscriberMailer < ApplicationMailer
     @subscriber = options[:subscriber]
     @event = options[:event]
     @filters = options[:filters]
+    @filter_names = @filters.map(&:name)
 
     mail subject: "New Event matching your filter",
       to: @subscriber.email

--- a/app/mailers/subscriber_mailer.rb
+++ b/app/mailers/subscriber_mailer.rb
@@ -6,6 +6,6 @@ class SubscriberMailer < ApplicationMailer
     @filter_names = @filters.map(&:name)
 
     mail subject: "New Event matching your filter",
-      to: @subscriber.email
+         to: @subscriber.email
   end
 end

--- a/app/query_objects/events/matching_filters_query.rb
+++ b/app/query_objects/events/matching_filters_query.rb
@@ -1,0 +1,51 @@
+module Events
+  class MatchingFiltersQuery
+    def initialize(event, relation = Filter.all)
+      @event = event
+      @relation = relation
+    end
+
+    def all
+      by_topic
+      by_town
+      by_min_starts_at
+      by_max_starts_at
+    end
+
+    private
+
+    def by_topic
+      @relation = @relation.where(topic_id: topics_ids)
+    end
+
+    def by_town
+      @relation = @relation.where(town_id: town_ids)
+    end
+
+    def by_min_starts_at
+      return @relation if @event.starts_at.blank?
+      @relation = @relation
+        .where("min_starts_at < ?", @event.starts_at)
+        .or(
+          @relation.where(min_starts_at: nil)
+        )
+    end
+
+    def by_max_starts_at
+      return @relation if @event.starts_at.blank?
+      @relation = @relation
+        .where("max_starts_at > ?", @event.starts_at)
+        .or(
+          @relation.where(max_starts_at: nil)
+        )
+    end
+
+    def topics_ids
+      @topics_ids ||= @event.topics.pluck(:id).push(nil).uniq
+    end
+
+    def town_ids
+      @town_ids ||= [@event.town.id, nil]
+    end
+  end
+end

--- a/app/query_objects/events/matching_filters_query.rb
+++ b/app/query_objects/events/matching_filters_query.rb
@@ -25,19 +25,19 @@ module Events
     def by_min_starts_at
       return @relation if @event.starts_at.blank?
       @relation = @relation
-        .where("min_starts_at < ?", @event.starts_at)
-        .or(
-          @relation.where(min_starts_at: nil)
-        )
+                  .where("min_starts_at < ?", @event.starts_at)
+                  .or(
+                    @relation.where(min_starts_at: nil)
+                  )
     end
 
     def by_max_starts_at
       return @relation if @event.starts_at.blank?
       @relation = @relation
-        .where("max_starts_at > ?", @event.starts_at)
-        .or(
-          @relation.where(max_starts_at: nil)
-        )
+                  .where("max_starts_at > ?", @event.starts_at)
+                  .or(
+                    @relation.where(max_starts_at: nil)
+                  )
     end
 
     def topics_ids

--- a/spec/factories/filters.rb
+++ b/spec/factories/filters.rb
@@ -1,5 +1,6 @@
 FactoryGirl.define do
   factory :filter do
+    user
     town
     name { Faker::Lorem.word }
   end

--- a/spec/jobs/notify_subscribers_job_spec.rb
+++ b/spec/jobs/notify_subscribers_job_spec.rb
@@ -18,6 +18,10 @@ describe NotifySubscribersJob do
   let(:event) { create :event }
 
   describe "#perform_now" do
+    subject(:job_call) do
+      described_class.perform_now(event_id: event.id)
+    end
+
     before do
       allow(Events::MatchingFiltersQuery)
         .to receive(:new).with(event) { matching_filters }
@@ -26,10 +30,6 @@ describe NotifySubscribersJob do
     let(:matching_filters) do
       instance_double "Events::MatchingFiltersQuery",
         all: Filter.where(id: matching_filters_ids)
-    end
-
-    subject(:job_call) do
-      described_class.perform_now(event_id: event.id)
     end
 
     it "sends an email to all subscriber with matching filters" do

--- a/spec/jobs/notify_subscribers_job_spec.rb
+++ b/spec/jobs/notify_subscribers_job_spec.rb
@@ -1,0 +1,54 @@
+require "rails_helper"
+
+describe NotifySubscribersJob do
+  include ActiveJob::TestHelper
+
+  let!(:ivan) { create :user }
+  let!(:petr) { create :user }
+  let!(:vasya) { create :user }
+
+  let!(:ivan_filters) { create_list :filter, 2, user: ivan }
+  let!(:petr_filters) { create_list :filter, 2, user: petr }
+  let!(:vasya_filters) { create_list :filter, 2, user: vasya }
+
+  let(:matching_filters_ids) do
+    ivan_filters.pluck(:id).push(vasya_filters.first.id)
+  end
+
+  let(:event) { create :event }
+
+  describe "#perform_now" do
+    before do
+      allow(Events::MatchingFiltersQuery)
+        .to receive(:new).with(event) { matching_filters }
+    end
+
+    let(:matching_filters) do
+      instance_double "Events::MatchingFiltersQuery",
+        all: Filter.where(id: matching_filters_ids)
+    end
+
+    subject(:job_call) do
+      described_class.perform_now(event_id: event.id)
+    end
+
+    it "sends an email to all subscriber with matching filters" do
+      expect(NotifySubscriberJob)
+        .to receive(:perform_later)
+        .with(
+          subscriber_id: ivan.id,
+          filter_ids: ivan_filters.map(&:id).sort,
+          event_id: event.id
+        )
+      expect(NotifySubscriberJob)
+        .to receive(:perform_later)
+        .with(
+          subscriber_id: vasya.id,
+          filter_ids: [vasya_filters.first.id],
+          event_id: event.id
+        )
+
+      job_call
+    end
+  end
+end

--- a/spec/query_objects/events/matching_filters_query_spec.rb
+++ b/spec/query_objects/events/matching_filters_query_spec.rb
@@ -1,0 +1,61 @@
+require "rails_helper"
+
+describe Events::MatchingFiltersQuery do
+  subject(:filters_for_event) do
+    described_class.new(event).all
+  end
+
+  let!(:event) do
+    create :event,
+      town: matching_town,
+      topics: [matching_topic1, matching_topic2],
+      starts_at: 1.day.ago
+  end
+
+  let(:matching_town) { create :town }
+  let(:unmatching_town) { create :town }
+  let(:matching_topic1) { create :topic }
+  let(:matching_topic2) { create :topic }
+  let(:unrelated_topic) { create :topic }
+  let!(:matching_filter1) do
+    create :filter, topic: matching_topic1, town: matching_town
+  end
+  let!(:matching_filter2) do
+    create :filter, topic: matching_topic2, town: nil
+  end
+  let!(:matching_filter3) do
+    create :filter, topic: nil, town: matching_town
+  end
+  let!(:matching_filter4) do
+    create :filter,
+      topic: nil,
+      town: matching_town,
+      min_starts_at: 2.days.ago,
+      max_starts_at: 1.day.since
+  end
+  let!(:unmatching_filter1) do
+    create :filter, topic: matching_topic1, town: unmatching_town
+  end
+  let!(:unmatching_filter2) do
+    create :filter, topic: unrelated_topic, town: matching_town
+  end
+  let!(:unmatching_filter3) do
+    create :filter, topic: nil, town: unmatching_town
+  end
+  let!(:unmatching_filter4) do
+    create :filter,
+      topic: nil,
+      town: matching_town,
+      min_starts_at: 3.days.ago,
+      max_starts_at: 2.days.ago
+  end
+
+  it "returns list of matching filters for event" do
+    expect(filters_for_event).to match_array [
+      matching_filter1,
+      matching_filter2,
+      matching_filter3,
+      matching_filter4
+    ]
+  end
+end


### PR DESCRIPTION
add background job that, given specific event, finds all users that have corresponding filters, and schedules email notifications to these users